### PR TITLE
API Doc: Fixed Typo

### DIFF
--- a/entries/hashtag.xml
+++ b/entries/hashtag.xml
@@ -74,5 +74,5 @@
 			</p>
     	]]></html>
 	</example>
-	<category slug="event"/>
+	<category slug="events"/>
 </entry>


### PR DESCRIPTION
Changed "event" back to "events"
