### PR TITLE
Update grunt.js with 'use strict' to support latest version of grunt

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -1,6 +1,8 @@
 /*jshint node:true */
 module.exports = function( grunt ) {
 
+"use strict";
+
 var entryFiles = grunt.file.expandFiles( "entries/*.xml" );
 
 grunt.loadNpmTasks( "grunt-clean" );


### PR DESCRIPTION
Ben told us today that grunt.js now requires "use strict"; for the lastest version of grunt.  This pull request adds the needed line to grunt.js and will allow allow you to grunt deploy without errors on the lint step.
