### PR TITLE
Pageinit example code that works

### DIFF
--- a/entries/pageinit.xml
+++ b/entries/pageinit.xml
@@ -5,7 +5,7 @@
 	<longdesc>
 		<p>We recommend binding to this event instead of DOM ready() because this will work regardless of whether the page is loaded directly or if the content is pulled into another page as part of the Ajax navigation system.</p>
 <pre><code>
-$( "#aboutPage" ).on( "pageinit", function( event ) {
+$( document ).on( "pageinit", "#aboutPage", function( event ) {
   alert( "This page was just enhanced by jQuery Mobile!" );
 });
 </code></pre>


### PR DESCRIPTION
Since Live was depricated you need to link to go through the $(document) object or this event will never fire.

Broken Example: http://jsfiddle.net/digiguru/qR9y7/3/

Fixed example: http://jsfiddle.net/digiguru/qR9y7/6/
