### PR TITLE
Path: Create subcategory for grouped methods.

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -12,6 +12,11 @@
 	<category name="Methods" slug="methods">
 		<desc><![CDATA[
 			<p>jQuery Mobile exposes several methods and properties on the $.mobile object for use in your applications.</p>]]></desc>
+		<category name="Path" slug="path">
+			<desc><![CDATA[
+				<p>A collection of methods for dealing with paths.</p>
+			]]></desc>
+		</category>
 	</category>
 	<category name="CSS Framework" slug="css-framework">
 		<desc><![CDATA[

--- a/entries/jQuery.mobile.path.get.xml
+++ b/entries/jQuery.mobile.path.get.xml
@@ -46,5 +46,5 @@ $(document).ready(function() {
 	<longdesc>
 		<p>Utility method for determining the directory portion of an URL. If the URL has no trailing slash, the last component of the URL is considered to be a file. This function returns the directory portion of a given URL.</p>
 	</longdesc>
-	<category slug="methods"/>
+	<category slug="methods/path"/>
 </entry>

--- a/entries/jQuery.mobile.path.isAbsoluteUrl.xml
+++ b/entries/jQuery.mobile.path.isAbsoluteUrl.xml
@@ -43,5 +43,5 @@ $(document).ready(function() {
 	<longdesc>
 		<p>Utility method for determining if a URL is absolute. This function returns a boolean true if the URL is absolute, false if not.</p>
 	</longdesc>
-	<category slug="methods"/>
+	<category slug="methods/path"/>
 </entry>

--- a/entries/jQuery.mobile.path.isRelativeUrl.xml
+++ b/entries/jQuery.mobile.path.isRelativeUrl.xml
@@ -43,5 +43,5 @@ $(document).ready(function() {
 	<longdesc>
 		<p>Utility method for determining if a URL is relative variant. This function returns a boolean true if the URL is relative, false if it is absolute.</p>
 	</longdesc>
-	<category slug="methods"/>
+	<category slug="methods/path"/>
 </entry>


### PR DESCRIPTION
I don't get why this produces the following error message:

```
Error: post jQuery.mobile.path.get has a category term slug of 'methods/path', but no such term exists.
```
