### PR TITLE
Checkboxradio: Fixed a bug of sample code for "Field containers" in Radio buttons of 1-4 branch.

### DIFF
--- a/entries/checkboxradio.xml
+++ b/entries/checkboxradio.xml
@@ -118,16 +118,16 @@
 &lt;div class="ui-field-contain"&gt;
 	&lt;fieldset data-role="controlgroup"&gt;
 		&lt;legend&gt;Choose a pet:&lt;/legend&gt;
-		&lt;input type="radio" name="radio-choice-2" id="radio-choice-21" value="choice-1" checked="checked" /&gt;
+		&lt;input type="radio" name="radio-choice-2" id="radio-choice-1" value="choice-1" checked="checked" /&gt;
 		&lt;label for="radio-choice-1">Cat&lt;/label&gt;
 
-		&lt;input type="radio" name="radio-choice-2" id="radio-choice-22" value="choice-2" /&gt;
+		&lt;input type="radio" name="radio-choice-2" id="radio-choice-2" value="choice-2" /&gt;
 		&lt;label for="radio-choice-2">Dog&lt;/label&gt;
 
-		&lt;input type="radio" name="radio-choice-2" id="radio-choice-23" value="choice-3" /&gt;
+		&lt;input type="radio" name="radio-choice-2" id="radio-choice-3" value="choice-3" /&gt;
 		&lt;label for="radio-choice-3">Hamster&lt;/label&gt;
 
-		&lt;input type="radio" name="radio-choice-2" id="radio-choice-24" value="choice-4" /&gt;
+		&lt;input type="radio" name="radio-choice-2" id="radio-choice-4" value="choice-4" /&gt;
 		&lt;label for="radio-choice-4">Lizard&lt;/label&gt;
 	&lt;/fieldset&gt;
 &lt;/div&gt;


### PR DESCRIPTION
This is a simple pull request.

Currently, the sample code for "Field containers" of Radio buttons isn't set the for attribute of the label to match the id of the input, so the sample code doesn't work properly.

I fixed ids in the sample code by following radiobutton/example3.html.
