### PR TITLE
Entries: collapsible: Fixed a typo in the example code for "Providing pre-rendered markup" (1-4 branch).

### DIFF
--- a/entries/collapsible.xml
+++ b/entries/collapsible.xml
@@ -105,7 +105,7 @@
 <pre><code>
 &lt;div data-role="collapsible" data-enhanced="true" class="ui-collapsible ui-collapsible-inset ui-corner-all ui-collapsible-collapsed" data-collapsed-icon="arrow-r"&gt;
 	&lt;h2 class="ui-collapsible-heading ui-collapsible-heading-collapsed"&gt;
-		&lt;a href="#" class="ui-collapsible-heading-toggle ui-btn ui-btn-icon-left ui-icon-arrow-d"&gt;
+		&lt;a href="#" class="ui-collapsible-heading-toggle ui-btn ui-btn-icon-left ui-icon-arrow-r"&gt;
 			Pre-rendered collapsible
 			&lt;span class="ui-collapsible-heading-status"&gt; click to expand contents&lt;/span&gt;
 		&lt;/a&gt;


### PR DESCRIPTION
This is simple pull request.
I think that "arrow-d" of https://github.com/jquery/api.jquerymobile.com/blob/1-4/entries/collapsible.xml#L108 is a typo.
So I changed "arrow-d" to "arrow-r".
