### PR TITLE
Fix orientationchange disable property documentation

### DIFF
--- a/entries/orientationchange.xml
+++ b/entries/orientationchange.xml
@@ -4,12 +4,12 @@
 	<desc>Device portrait/landscape orientation event</desc>
 	<longdesc>
 		<p>The jQuery Mobile <code>orientationchange</code> event triggers when a device orientation changes, either by turning the device vertically or horizontally. When bound to this event the callback function has the event object. The event object contains an <code>orientation</code> property equal to either <code>"portrait"</code> or <code>"landscape"</code>.</p>
-		<p>Note that we bind to the browser's resize event when <code>orientationchange</code> is not natively supported or if <code>$.event.special.orientationchange.disabled</code> is set to <code>false</code>.</p>
+		<p>Note that we bind to the browser's resize event when <code>orientationchange</code> is not natively supported or if <code>$.event.special.orientationchange.disabled</code> is set to <code>true</code>.</p>
 
 		<div class="warning">
 			<h3>orientationchange timing</h3>
 
-			<p>The timing of the <code>orientationchange</code> event with relation to the change of the client height and width is different between browsers, though the current implementation will give you the correct value for <code>event.orientation</code> derived from <code>window.orientation</code>. This means that if your bindings are dependent on the height and width values you may want to disable <code>orientationChange</code> altogether with <code>$.event.special.orientationchange.disabled = false</code> to let the fallback resize code trigger your bindings.</p>
+			<p>The timing of the <code>orientationchange</code> event with relation to the change of the client height and width is different between browsers, though the current implementation will give you the correct value for <code>event.orientation</code> derived from <code>window.orientation</code>. This means that if your bindings are dependent on the height and width values you may want to disable <code>orientationChange</code> altogether with <code>$.event.special.orientationchange.disabled = true</code> to let the fallback resize code trigger your bindings.</p>
 		</div>
 	</longdesc>
 	<added>1.0</added>


### PR DESCRIPTION
The documentation states that for the `orientationchange` event to only use size comparisons without listening for browser-generated orientationchange events, one has to set the `$.mobile.orientationChangeEnabled` to `false`. The problem is that the current implementation for this event only checks for `$.event.special.orientationchange.disabled` property. There is an actual reference in code to  `$.mobile.orientationChangeEnabled` but it is not used anywhere and seems to be obsolete. The `orientationchange.disabled` property is assumed to be boolean but its semantics are the other way around compared to the `orientationChangeEnabled` property. This means that to not use browser-generated orientationchange events, one has to set this property to `true`. The default value for this property is not defined, this will evaluate to `false` in code by default which enables listening to browser-generated orientationchange events.

This pull request fixes the documentation to describe the property the code actually listens to instead of the dead one.
