### PR TITLE
Navigate: Warn that the method should only be used on its own

### DIFF
--- a/entries/jQuery.mobile.navigate.xml
+++ b/entries/jQuery.mobile.navigate.xml
@@ -4,6 +4,7 @@
 	<desc>Alter the url and track history. Works for browsers with and without the new history API.</desc>
 	<longdesc>
 		<p>The <code>$.mobile.navigate</code> method provides a uniform history manipulation API for browsers that support the new history API and those that don't (hashchange). It works in concert with the navigate event by storing and retrieving arbitrary data in association with a URL (much like <code>popState</code> and <code>replaceState</code>). When the user returns to a URL set by the navigate method the navigate event is triggered with the associated data.</p>
+		<p id="low-level" class="warning"><strong>Note:</strong> This method is a low-level utility which can be used on its own. If you use the jQuery Mobile navigation framework, you should not separately use this utility. Instead, you should use <a href="/pagecontainer/">pagecontainer</a> event handlers to influence the navigation process.</p>
 	</longdesc>
 	<signature>
 		<argument name="url">


### PR DESCRIPTION
It should not be used when a full-fledged jQM navigation implementation is
present because the idea is to allow jQM to handle the navigation, since there
are many safeguards in the jQM navigation code that make it robust under a
variety of circumstances.

Fixes gh-238
