### PR TITLE
Filterable: Document events beforefilter and filter

### DIFF
--- a/entries/filterable.xml
+++ b/entries/filterable.xml
@@ -225,8 +225,10 @@ $.mobile.filterable.prototype.options.filterCallback = function( index, searchVa
 		<event name="filter">
 			<desc>Triggered after the widget has performed the filtering on the list of children. The <code>ui</code> parameter contains the list of children that was processed.</desc>
 			<argument name="event" type="Event"/>
-			<argument name="ui" type="jQuery">
-				<desc>The list of children.</desc>
+			<argument name="ui" type="Object">
+				<property name="items" type="jQuery">
+					<desc>A jQuery collection object containing the items over which the filter has iterated.</desc>
+				</property>
 			</argument>
 		</event>
 	</events>


### PR DESCRIPTION
Fixes gh-224
Fixes gh-225

Note: The documentation for the filter event generates a note saying the "ui" parameter is empty, despite the fact that it is not of type Object, but of type jQuery. See https://github.com/jquery/grunt-jquery-content/issues/48 and https://github.com/jquery/grunt-jquery-content/pull/49.
