### PR TITLE
data-attribute: noted data-iconshadow as deprecated

### DIFF
--- a/pages/data-attribute.html
+++ b/pages/data-attribute.html
@@ -27,7 +27,7 @@
 	</tr>
 	<tr>
 		<th>data-iconshadow</th>
-		<td><strong>true</strong> | false <span class="warning">Deprecated as of 1.4.0 and will be removed in 1.5.0.</span></td>
+		<td>true | <strong>false</strong> <span class="warning">Deprecated as of 1.4.0 and will be removed in 1.5.0.</span></td>
 	</tr>
 	<tr>
 		<th>data-inline</th>


### PR DESCRIPTION
fixes #264
