### PR TITLE
Corrects: API Documentation

### DIFF
--- a/entries/swipe.xml
+++ b/entries/swipe.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <entry name="swipe" type="event" return="jQuery" example-selector="window">
 	<title>swipe</title>
-	<desc>Triggered when a horizontal drag of 30px or more (and less than 75px vertically) occurs within 1 second duration.</desc>
+	<desc>Triggered when a horizontal drag of 30px or more (and less than 30px vertically) occurs within 1 second duration.</desc>
 	<longdesc>
-		<p>Triggered when a horizontal drag of 30px or more (and less than 75px vertically) occurs within 1 second duration but these can be configured:
+		<p>Triggered when a horizontal drag of 30px or more (and less than 30px vertically) occurs within 1 second duration but these can be configured:
 			<ul>
 				<li><code>$.event.special.swipe.scrollSupressionThreshold</code> (default: 10px) – More than this horizontal displacement, and we will suppress scrolling.</li>
 				<li><code>$.event.special.swipe.durationThreshold</code> (default: 1000ms) – More time than this, and it isn't a swipe.</li>
 				<li><code>$.event.special.swipe.horizontalDistanceThreshold</code> (default: 30px) – Swipe horizontal displacement must be more than this.</li>
-				<li><code>$.event.special.swipe.verticalDistanceThreshold</code> (default: 75px) – Swipe vertical displacement must be less than this.</li>
+				<li><code>$.event.special.swipe.verticalDistanceThreshold</code> (default: 30px) – Swipe vertical displacement must be less than this.</li>
 			</ul>
 		</p>
 		<p>The swipe event can also be extend to add your own logic or functionality. The following methods can be extended:</p>

--- a/entries/swipeleft.xml
+++ b/entries/swipeleft.xml
@@ -3,7 +3,7 @@
 	<title>swipeleft</title>
 	<desc>Triggered when a swipe event occurs moving in the left direction.</desc>
 	<longdesc>
-		<p>Triggered when a horizontal drag of 30px or more (and less than 75px vertically) occurs within 1 second duration in the left direction. See <a href="../swipe/">the swipe event entry</a> for more detailed information on the swipe event.</p>
+		<p>Triggered when a horizontal drag of 30px or more (and less than 30px vertically) occurs within 1 second duration in the left direction. See <a href="../swipe/">the swipe event entry</a> for more detailed information on the swipe event.</p>
 	</longdesc>
 	<added>1.0</added>
 	<signature>

--- a/entries/swiperight.xml
+++ b/entries/swiperight.xml
@@ -3,7 +3,7 @@
 	<title>swiperight</title>
 	<desc>Triggered when a swipe event occurs moving in the right direction.</desc>
 	<longdesc>
-		<p>Triggered when a horizontal drag of 30px or more (and less than 75px vertically) occurs within 1 second duration in the right direction. See <a href="../swipe/">the swipe event entry</a> for more detailed information on the swipe event.</p>
+		<p>Triggered when a horizontal drag of 30px or more (and less than 30px vertically) occurs within 1 second duration in the right direction. See <a href="../swipe/">the swipe event entry</a> for more detailed information on the swipe event.</p>
 	</longdesc>
 	<added>1.0</added>
 	<signature>


### PR DESCRIPTION
In the API documentation for swipe events the default vertical distance
threshold value is written as 75px while in the code it is actually 30px.

Fixes gh-#365