### PR TITLE
Orientationchange: Changed height of example iframe so get both results

### DIFF
--- a/entries/orientationchange.xml
+++ b/entries/orientationchange.xml
@@ -19,7 +19,7 @@
 		</property>
 	</signature>
 	<example>
-		<height>90</height>
+		<height>490</height>
 		<desc>Visit this from your orientation-enabled device to see it in action!</desc>
 		<code><![CDATA[
 // Bind an event to window.orientationchange that, when the device is turned,


### PR DESCRIPTION
Addresses concerns in gh-128. The user can just modify the width of the window and see both results: portrait and landscape.